### PR TITLE
Setup Physics user-data at startup only (instead of at each frame)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,14 +142,10 @@ fn setup_physics(commands: &mut Commands) {
 }
 
 fn setup_user_data(
-    mut colliders: ResMut<ColliderSet>,
-    query: Query<(Entity, &ColliderHandleComponent)>,
+    mut query: Query<(Entity, &mut ColliderBuilder)>,
 ) {
-    for (entity, collider_handle) in &mut query.iter() {
-        if let Some(collider) = colliders.get_mut(collider_handle.handle()) {
-            collider.user_data = entity.to_bits() as u128;
-            // println!("set user data! {}", entity.to_bits())
-        }
+    for (entity, mut builder) in query.iter_mut() {
+        builder.user_data = entity.to_bits().into()
     }
 }
 
@@ -241,7 +237,7 @@ fn main() {
         .add_startup_system(setup_graphics.system())
         // setup physics
         .add_startup_system(setup_physics.system())
-        .add_system(setup_user_data.system())
+        .add_startup_system_to_stage(bevy::app::startup_stage::POST_STARTUP, setup_user_data.system())
         .add_system(thruster_system.system())
         .add_system(display_events.system())
         .run();


### PR DESCRIPTION
Here we go.


There was two things.

1. If we execute the system *before* `bevy_rapier` kicked in, we have to update the `ColliderBuilder` components (the colliders are not yet created)
2. The `chain` actually doesn't work, because the commands will not have been executed yet. So it *has to* be on a later stage.
